### PR TITLE
Added missing CompletionHandler

### DIFF
--- a/Sources/THTTPSessionTransport.swift
+++ b/Sources/THTTPSessionTransport.swift
@@ -112,10 +112,19 @@ public class THTTPSessionTransport: TAsyncTransport {
 
     do {
       task = try factory.taskWithRequest(request, completionHandler: { (data, response, taskError) in
-        
+
+        // Check if there was an error with the network
+        if taskError != nil {
+            error = TTransportError(error: .timedOut)
+            completed(self, error)
+            return
+        }
+
         // Check response type
         if taskError == nil && !(response is HTTPURLResponse) {
-          error = THTTPTransportError(error: .invalidResponse)
+            error = THTTPTransportError(error: .invalidResponse)
+            completed(self, error)
+            return
         }
         
         // Check status code


### PR DESCRIPTION
The THTTPSessionTransport.flush did not call the completion handler of the taskError set.

I tested this we putting the phone in FlightMode. Without calling the completion handler the thread was blocked since the Semaphore signal was never called.