### PR TITLE
Fix for large numbers on TCompactProtocol.

### DIFF
--- a/Sources/TCompactProtocol.swift
+++ b/Sources/TCompactProtocol.swift
@@ -222,11 +222,11 @@ public class TCompactProtocol: TProtocol {
   ///
   /// - returns: zigzaged UInt32
   func i32ToZigZag(_ n : Int32) -> UInt32 {
-    return UInt32(n << 1) ^ UInt32(n >> 31)
+    return UInt32(bitPattern: Int32(n << 1) ^ Int32(n >> 31))
   }
 
   func i64ToZigZag(_ n : Int64) -> UInt64 {
-    return UInt64(n << 1) ^ UInt64(n >> 63)
+    return UInt64(bitPattern: Int64(n << 1) ^ Int64(n >> 63))
   }
 
   func zigZagToi32(_ n: UInt32) -> Int32 {

--- a/Sources/TSocketTransport.swift
+++ b/Sources/TSocketTransport.swift
@@ -83,8 +83,8 @@ public class TCFSocketTransport: TStreamTransport {
         CFWriteStreamSetProperty(writeStream, .shouldCloseNativeSocket, kCFBooleanTrue)
       
         if secure {
-            CFReadStreamSetProperty(readStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL._rawValue)
-            CFWriteStreamSetProperty(writeStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL._rawValue)
+            CFReadStreamSetProperty(readStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL.rawValue as CFString)
+            CFWriteStreamSetProperty(writeStream, .socketSecurityLevel, StreamSocketSecurityLevel.negotiatedSSL.rawValue as CFString)
         }
 
       inputStream = readStream as InputStream


### PR DESCRIPTION
LONG_MAX and LONG_LONG_MAX where not supported properly. Same for negative numbers.