### PR TITLE
make TClient inits 'required'

### DIFF
--- a/Sources/TClient.swift
+++ b/Sources/TClient.swift
@@ -22,12 +22,12 @@ open class TClient {
   public let inProtocol: TProtocol
   public let outProtocol: TProtocol
 
-  public init(inoutProtocol: TProtocol) {
+  required public init(inoutProtocol: TProtocol) {
     self.inProtocol = inoutProtocol
     self.outProtocol = inoutProtocol
   }
 
-  public init(inProtocol: TProtocol, outProtocol: TProtocol) {
+  required public init(inProtocol: TProtocol, outProtocol: TProtocol) {
     self.inProtocol = inProtocol
     self.outProtocol = outProtocol
   }


### PR DESCRIPTION
Hi, can we have these inits as '`required`', so this piece of code is possible:
    
```
    func clientFor<T: TClient>(proto: TProtocol) -> T {
        let client = T(inoutProtocol: proto)
        return client
    }
```
